### PR TITLE
Make subnet integration perms more flexible, with generic admin/invoke/etc. roles.

### DIFF
--- a/api/chute/router.py
+++ b/api/chute/router.py
@@ -42,7 +42,6 @@ from api.chute.templates import (
 from api.gpu import SUPPORTED_GPUS
 from api.chute.response import ChuteResponse
 from api.chute.util import (
-    get_chute_by_id_or_name,
     selector_hourly_price,
     get_one,
     is_shared,
@@ -51,7 +50,7 @@ from api.chute.util import (
 from api.instance.schemas import Instance
 from api.instance.util import get_chute_target_manager
 from api.user.schemas import User
-from api.user.service import get_current_user, chutes_user_id
+from api.user.service import get_current_user, chutes_user_id, subnet_role_accessible
 from api.image.schemas import Image
 from api.image.util import get_image_by_id_or_name
 from api.permissions import Permissioning
@@ -68,7 +67,7 @@ from api.util import (
     semcomp,
     limit_deployments,
     get_current_hf_commit,
-    is_affine_registered,
+    is_registered_to_subnet,
     notify_deleted,
     image_supports_cllmv,
 )
@@ -608,6 +607,7 @@ async def get_chute_code(
             )
         )
         or "/affine" in chute.name.lower()
+        or subnet_role_accessible(chute, current_user, admin=True)
     ):
         authorized = True
     if not authorized:
@@ -636,6 +636,7 @@ async def warm_up_chute(
         not chute.public
         and not chute.user_id == current_user.user_id
         and not await is_shared(chute.chute_id, current_user.user_id)
+        and not subnet_role_accessible(chute, current_user)
     ):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -751,8 +752,16 @@ async def get_chute(
     """
     Load a chute by ID or name.
     """
-    chute = await get_chute_by_id_or_name(chute_id_or_name, db, current_user, load_instances=True)
-    if not chute:
+    chute = await get_one(chute_id_or_name)
+    authorized = False
+    if chute:
+        if (
+            chute.user_id == current_user.user_id
+            or await is_shared(chute.chute_id, current_user.user_id)
+            or subnet_role_accessible(chute, current_user, admin=True)
+        ):
+            authorized = True
+    if not authorized:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Chute not found, or does not belong to you",
@@ -762,50 +771,44 @@ async def get_chute(
     return response
 
 
-@router.delete("/{chute_id_or_name:path}")
+@router.delete("/{chute_id}")
 async def delete_chute(
-    chute_id_or_name: str,
+    chute_id: str,
     db: AsyncSession = Depends(get_db_session),
     current_user: User = Depends(get_current_user(purpose="chutes")),
 ):
     """
-    Delete a chute by ID or name.
+    Delete a chute by ID.
     """
-    chute = None
-    if (
-        current_user.has_role(Permissioning.affine_admin)
-        and current_user.user_id != await chutes_user_id()
-    ):
-        try:
-            uuid.UUID(chute_id_or_name)
-        except ValueError:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Must use chute UUID to delete affine models.",
-            )
-        chute = await get_one(chute_id_or_name)
-        if not chute:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Chute not found",
-            )
-        if chute.user_id != current_user.user_id and "affine" not in chute.name.lower():
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Cannot delete non-affine chutes not owned by you.",
-            )
-        logger.warning(
-            f"AFFINE DEV DELETION TRIGGERED: {current_user.user_id=} "
-            f"{current_user.username=} {chute.chute_id=} {chute.name=}"
+    try:
+        uuid.UUID(chute_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Must use chute UUID to delete.",
         )
-    else:
-        chute = await get_chute_by_id_or_name(chute_id_or_name, db, current_user)
-        if not chute or chute.user_id != current_user.user_id:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Chute not found, or does not belong to you",
-            )
 
+    # Make sure the chute exists and the user has permissions to delete it.
+    # - user owns it
+    # - part of a subnet integration and user is a subnet admin
+    chute = await get_one(chute_id)
+    allowed = False
+    if chute:
+        if chute.user_id == current_user.user_id:
+            allowed = True
+        if subnet_role_accessible(chute, current_user, admin=True):
+            allowed = True
+            logger.warning(
+                f"Subnet admin triggered chute deletion: {current_user.user_id=} "
+                f"{current_user.username=} {chute.chute_id=} {chute.name=}"
+            )
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Chute not found, or does not belong to you",
+        )
+
+    # Perform the deletion.
     chute_id = chute.chute_id
     version = chute.version
     await db.delete(chute)
@@ -819,7 +822,6 @@ async def delete_chute(
             }
         ).decode(),
     )
-
     return {"chute_id": chute_id, "deleted": True}
 
 
@@ -914,7 +916,7 @@ async def _deploy_chute(
             ),
         )
 
-    affine_dev = await is_affine_registered(db, current_user)
+    affine_dev = await is_registered_to_subnet(db, current_user, 120)
     if (
         current_user.user_id != await chutes_user_id()
         and not current_user.has_role(Permissioning.unlimited_dev)
@@ -1175,7 +1177,7 @@ async def _deploy_chute(
                 }
             ).decode(),
         )
-    return await get_chute_by_id_or_name(chute.chute_id, db, current_user, load_instances=True)
+    return await get_one(chute.chute_id, nonce=int(time.time()))
 
 
 @router.post("/", response_model=ChuteResponse)
@@ -1190,7 +1192,7 @@ async def deploy_chute(
     """
     is_affine_model = False
     affine_checked = False
-    if await is_affine_registered(db, current_user):
+    if await is_registered_to_subnet(db, current_user, 120):
         if not re.match(r"[^/]+/affine.*", chute_args.name, re.I):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -1198,13 +1200,38 @@ async def deploy_chute(
             )
         affine_checked = True
 
+    # Score unique chute name prefix.
+    if (
+        "turbovision" in chute_args.name.lower()
+        and not current_user.has_role(Permissioning.unlimited_dev)
+        and not subnet_role_accessible(chute_args, current_user, admin=True)
+        and not is_registered_to_subnet(db, current_user, 44)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only score registered miners/users may deploy chutes with 'turbovision' in the name!",
+        )
+
+    # Babelbit unique chute name prefix.
+    if (
+        "babelbit" in chute_args.name.lower()
+        and not current_user.has_role(Permissioning.unlimited_dev)
+        and not subnet_role_accessible(chute_args, current_user, admin=True)
+        and not is_registered_to_subnet(db, current_user, 999)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only babelbit registered miners/users may deploy chutes with 'babelbit' in the name!",
+        )
+
     # Affine special handling.
     if (
         "affine" in chute_args.name.lower()
         and not current_user.has_role(Permissioning.unlimited_dev)
+        and not subnet_role_accessible(chute_args, current_user, admin=True)
         and current_user.username.lower() not in ("affine", "affine2", "unconst", "nonaffine")
     ):
-        if not affine_checked and not await is_affine_registered(db, current_user):
+        if not affine_checked and not await is_registered_to_subnet(db, current_user, 120):
             logger.warning(
                 "Attempted affine deployment by unregistered hotkey: "
                 f"{current_user.user_id=} {current_user.username=}"
@@ -1294,37 +1321,6 @@ async def deploy_chute(
         use_rolling_update=not is_affine_model,
         accept_fee=accept_fee,
     )
-
-    # Auto-share affine chutes with affine admin users.
-    if "/affine" in chute.name.lower():
-        af_dev_user_ids = (
-            (
-                await db.execute(
-                    select(User.user_id).where(
-                        User.permissions_bitmask.op("&")(Permissioning.affine_admin.bitmask) != 0
-                    )
-                )
-            )
-            .unique()
-            .scalars()
-            .all()
-        )
-        if af_dev_user_ids:
-            stmt = insert(ChuteShare).values(
-                [
-                    {
-                        "chute_id": chute.chute_id,
-                        "shared_by": current_user.user_id,
-                        "shared_to": user_id,
-                        "shared_at": func.now(),
-                    }
-                    for user_id in af_dev_user_ids
-                    if user_id != current_user.user_id
-                ]
-            )
-            stmt = stmt.on_conflict_do_nothing()
-            await db.execute(stmt)
-
     return chute
 
 
@@ -1386,7 +1382,7 @@ async def easy_deploy_vllm_chute(
         detail="Easy deployment is currently disabled!",
     )
 
-    if await is_affine_registered(db, current_user):
+    if await is_registered_to_subnet(db, current_user, 120):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Easy vllm deployment method not supported for Affine currently.",
@@ -1621,7 +1617,7 @@ async def update_common_attributes(
     """
     Update readme, tagline, etc. (but not code, image, etc.).
     """
-    chute = await get_chute_by_id_or_name(chute_id_or_name, db, current_user, load_instances=True)
+    chute = await get_one(chute_id_or_name)
     if not chute or chute.user_id != current_user.user_id:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api/chute/util.py
+++ b/api/chute/util.py
@@ -319,12 +319,13 @@ async def _get_one(name_or_id: str, nonce: int = None):
         return chute
 
 
-async def get_one(name_or_id: str):
+async def get_one(name_or_id: str, nonce: int = None):
     """
     Wrapper around the actual cached get_one with 30 second nonce to force refresh.
     """
-    nonce = int(time.time())
-    nonce -= nonce % 30
+    if not nonce:
+        nonce = int(time.time())
+        nonce -= nonce % 30
     return await _get_one(name_or_id, nonce=nonce)
 
 

--- a/api/instance/router.py
+++ b/api/instance/router.py
@@ -23,7 +23,6 @@ from sqlalchemy.dialects.postgresql import insert
 from api.gpu import SUPPORTED_GPUS
 from api.database import get_db_session, generate_uuid, get_session
 from api.config import settings
-from api.permissions import Permissioning
 from api.constants import (
     HOTKEY_HEADER,
     AUTHORIZATION_HEADER,
@@ -47,7 +46,7 @@ from api.instance.util import (
     load_launch_config_from_jwt,
 )
 from api.user.schemas import User
-from api.user.service import get_current_user, chutes_user_id
+from api.user.service import get_current_user, chutes_user_id, subnet_role_accessible
 from api.metasync import get_miner_by_hotkey
 from api.util import (
     semcomp,
@@ -1147,10 +1146,7 @@ async def stream_logs(
             detail="Instance not found.",
         )
     if instance.chute.user_id != current_user.user_id or instance.chute.public:
-        if (
-            not current_user.has_role(Permissioning.affine_admin)
-            or "affine" not in instance.chute.name.lower()
-        ):
+        if not subnet_role_accessible(instance.chute, current_user, admin=True):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You may only view logs for your own (private) chutes.",

--- a/api/invocation/router.py
+++ b/api/invocation/router.py
@@ -36,7 +36,7 @@ from api.util import (
     has_legacy_private_billing,
 )
 from api.user.schemas import User, InvocationQuota
-from api.user.service import get_current_user, chutes_user_id
+from api.user.service import get_current_user, chutes_user_id, subnet_role_accessible
 from api.report.schemas import Report, ReportArgs
 from api.database import get_db_session, get_session, get_db_ro_session
 from api.instance.util import get_chute_target_manager
@@ -312,7 +312,7 @@ async def _invoke(
         chute.public
         or chute.user_id == current_user.user_id
         or await is_shared(chute.chute_id, current_user.user_id)
-        or ("/affine" in chute.name.lower() and current_user.has_role(Permissioning.affine_admin))
+        or subnet_role_accessible(chute, current_user)
     ):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="No matching chute found!"
@@ -960,10 +960,7 @@ async def hostname_invocation(
                     chute.user_id != current_user.user_id
                     and not await is_shared(chute.chute_id, current_user.user_id)
                 )
-                and not (
-                    "/affine" in chute.name.lower()
-                    and current_user.has_role(Permissioning.affine_admin)
-                )
+                and subnet_role_accessible(chute, current_user)
             ):
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -51,13 +51,21 @@ class Permissioning:
         bitmask=1 << 9,
         description="Enable stake weighted quota (signed message with the coldkey)",
     )
-    affine_admin = Role(
+    subnet_admin = Role(
         bitmask=1 << 10,
-        description="Affine admin",
+        description="Subnet admin",
     )
     public_model_deployment = Role(
         bitmask=1 << 11,
-        description="Allow deploying models publicly.",
+        description="Allow deploying models publicly",
+    )
+    subnet_invoke = Role(
+        bitmask=1 << 12,
+        description="Allow invocation of private chutes of a subnet",
+    )
+    subnet_admin_assign = Role(
+        bitmask=1 << 13,
+        description="Allow granting subnet admin/request roles to other users, i.e. subnet role self-service",
     )
 
     @classmethod

--- a/api/user/schemas.py
+++ b/api/user/schemas.py
@@ -13,11 +13,13 @@ from sqlalchemy import (
     DateTime,
     Double,
     Boolean,
+    Integer,
     BigInteger,
     ForeignKey,
     select,
     case,
 )
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import relationship, validates
 from api.database import Base
 import hashlib
@@ -99,6 +101,9 @@ class User(Base):
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Netuid list, for admin roles.
+    netuids = Column(ARRAY(Integer), nullable=True)
 
     # Logo/avatar.
     logo_id = Column(String, ForeignKey("logos.logo_id", ondelete="SET NULL"), nullable=True)

--- a/api/user/service.py
+++ b/api/user/service.py
@@ -17,6 +17,7 @@ from fastapi.security import APIKeyHeader
 from api.constants import HOTKEY_HEADER, SIGNATURE_HEADER, AUTHORIZATION_HEADER
 from api.constants import NONCE_HEADER
 from api.util import nonce_is_valid, get_signing_message
+from api.permissioning import Permissioning
 from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter()
@@ -192,3 +193,19 @@ async def chutes_user():
             .scalar_one_or_none()
         )
     return router._chutes_user
+
+
+def subnet_role_accessible(chute, user, admin: bool = False):
+    netuid = None
+    if "/affine" in chute.name.lower():
+        netuid = 120
+    elif "/turbovision" in chute.name.lower():
+        netuid = 44
+    elif "/babelbit" in chute.name.lower():
+        netuid = 999
+    if not netuid:
+        return False
+    perms = [Permissioning.subnet_admin]
+    if not admin:
+        perms.append(Permissioning.subnet_invoke)
+    return user.netuids and netuid in user.netuids and any(user.has_role(perm) for perm in perms)

--- a/api/util.py
+++ b/api/util.py
@@ -169,14 +169,14 @@ async def is_valid_host(host: str) -> bool:
     return False
 
 
-async def is_affine_registered(session, user):
+async def is_registered_to_subnet(session, user, netuid):
     """
-    Check if a user is registered on affine (thereby allowing limited dev activity).
+    Check if a user is registered to a given subnet.
     """
     result = await session.execute(
         select(
             exists(
-                select(1).where(MetagraphNode.netuid == 120, MetagraphNode.hotkey == user.hotkey)
+                select(1).where(MetagraphNode.netuid == netuid, MetagraphNode.hotkey == user.hotkey)
             )
         )
     )


### PR DESCRIPTION
- track netuids per user
- subnet_admin role, distinct from subnet_invoke role
  - admins can see code, invoke, etc.
  - invoke can only make requests (e.g. a validator)
- subnet admin self-service role assign (to add new accounts as admins or invoke role)
- no need for ChuteShare objects with new subnet roles